### PR TITLE
Chapter 4's mistake

### DIFF
--- a/go-packages.tex
+++ b/go-packages.tex
@@ -299,7 +299,7 @@ test look we redefine our test function:
 \begin{lstlisting}
 // Entering the twilight zone
 func TestEven(t *testing.T) {
-        if ! Even(2) {
+        if !! Even(2) {
                 t.Log("2 should be odd!")
                 t.Fail()
         }   


### PR DESCRIPTION
In section "Testing packages", below sentence "To show how a failed test look we redefine our test function", I think it should be changed to 

<pre>
package even

import "testing"

func TestEven(t *testing.T) {
    if !! Even(2) {
        t.Log("2 should be odd!")
        t.Fail()
    }
}
</pre>
