### PR TITLE
Chapter 8's mistake

### DIFF
--- a/src/file.go
+++ b/src/file.go
@@ -6,8 +6,8 @@ func main() {
 	f, _ := os.Open("/etc/passwd") |\longremark{Open the file;}|
 	defer f.Close() |\longremark{Make sure we close it again;}|
 	for {
-		n, _ := f.Read(buf) |\longremark{Read up to 1023 bytes at the time;}|
+		n, _ := f.Read(buf) |\longremark{Read up to 1024 bytes at the time;}|
 		if n == 0 { break } |\longremark{We have reached the end of the file;}|
-		os.Stdout.Write(buf[0:n]) |\longremark{Write the contents to \var{Stdout};}|
+		os.Stdout.Write(buf[:n]) |\longremark{Write the contents to \var{Stdout};}|
 	}
 }


### PR DESCRIPTION
In section "Files and directories", because `buf := make([]byte, 1024),` `n,_:=f.Read(buf)` should Read up to 1024 bytes at the time, not 1023 bytes.

I also think change `os.Stdout.Write(buf[0:n])` to `os.Stdout.Write(buf[:n])` is more slice. :)
