### PR TITLE
Fix typo in go-interfaces.tex

### DIFF
--- a/go-interfaces.tex
+++ b/go-interfaces.tex
@@ -373,7 +373,7 @@ and \emph{then} access the tag.
 
 %% look at layout
 To make the difference between types and values more clear,
-that a look at the following code:
+take a look at the following code:
 \begin{lstlisting}[caption=Reflection and the type and value]
 func show(i interface{}) {
     switch t := i.(type) {


### PR DESCRIPTION
Fix typo: "that a look" => "take a look"
