### PR TITLE
Add a sidebar explanation of %v at the first point it's used in the book

### DIFF
--- a/go-basics.tex
+++ b/go-basics.tex
@@ -322,6 +322,7 @@ use them you need a variable of type \lstinline{complex128} (64
 bit real and imaginary parts) or \lstinline{complex64} (32 bit
 real and imaginary parts).
 Complex numbers are written as
+\gomarginpar{The Printf() verb %v, which isn't available to C's printf() function, means ``print the value in its default format''.}
 \var{re + im$i$}, where \var{re} is the real part,
 \var{im} is the imaginary part and $i$ is the literal '$i$' ($\sqrt{-1}$).
 An example of using complex numbers:


### PR DESCRIPTION
%v is not available to C's printf(). This is the first use of %v in the book... seems like a good place for an explanation (explanation could be improved).
