### PR TITLE
Fix for misspelling in Chapter 8

### DIFF
--- a/go-communication.tex
+++ b/go-communication.tex
@@ -12,7 +12,7 @@ The following is happening here:
 \showremarks
 If you want to use \first{buffered}{buffered} IO there is the
 \package{bufio}\index{package!bufio} package:
-\lstinputlisting[caption=Reading from a file (bufferd),label=src:bufread]{src/buffile.go}
+\lstinputlisting[caption=Reading from a file (buffered),label=src:bufread]{src/buffile.go}
 \showremarks
 
 \section{io.Reader}


### PR DESCRIPTION
buffered was misspelled in the caption.
