### PR TITLE
Fixed ubraces alignment for the listing "A function declaration".

### DIFF
--- a/fig/function.tex
+++ b/fig/function.tex
@@ -1,18 +1,18 @@
 \begin{lstlisting}[caption=A function declaration,label=src:function definition]
 |\begin{tikzpicture}[overlay]
-\ubrace{0.6,-1.5}{0.0,-1.5}{The keyword \key{func} is used to declare a function;}
+\ubrace{0.8,-1.5}{0.0,-1.5}{The keyword \key{func} is used to declare a function;}
 %
-\ubrace{2.2,-1.5}{0.8,-1.5}{A function can optionally be bound to a specific type. %
+\ubrace{3.0,-1.5}{1.0,-1.5}{A function can optionally be bound to a specific type. %
 This is called the \first{\emph{receiver}}{receiver}. A function with a receiver is %
 a \index{method}{method}. This will be explored in chapter \ref{chap:interfaces};}
 %
-\ubrace{3.4,-1.5}{2.4,-1.5}{\emph{funcname} is the name of your function;}
+\ubrace{4.8,-1.5}{3.2,-1.5}{\emph{funcname} is the name of your function;}
 %
-\ubrace{4.5,-1.5}{3.6,-1.5}{The variable \var{q} of type \type{int} is %
+\ubrace{6.2,-1.5}{4.9,-1.5}{The variable \var{q} of type \type{int} is %
 the input parameter. The parameters are passed %
 \first{\emph{pass-by-value}}{pass-by-value} meaning they are copied;}
 %
-\ubrace{6.0,-1.5}{4.9,-1.5}{%
+\ubrace{8.2,-1.5}{6.4,-1.5}{%
 The variables \var{r} and \var{s} are the %
 \index{named return parameters}{named return parameters} for this function. %
 Functions in Go can have multiple return values, see section %
@@ -23,7 +23,7 @@ parameters not to be named you only give the types: %
 the parentheses. If your function is a subroutine and does not have %
 anything to return you may omit this entirely;}
 %
-\ubrace{8.2,-1.5}{6.3,-1.5}{This is the function's body. Note that %
+\ubrace{11.3,-1.5}{8.4,-1.5}{This is the function's body. Note that %
 \func{return} is a statement so the braces around the parameter(s) are %
 optional.}
 \end{tikzpicture}|


### PR DESCRIPTION
First off, I don't know if this is a fonts related issue (or anything else) or really a misalignment in the book.
I attach screenshots to show how it looks before & after on my system.
It would be great if anybody can confirm/refute this bug on their system.

Broken:
![broken](https://f.cloud.github.com/assets/994128/550757/b23e2a74-c319-11e2-9c32-0c3d288b7f39.png)

Fixed:
![fixed](https://f.cloud.github.com/assets/994128/550759/b69cc85a-c319-11e2-8edd-141984f1647e.png)
